### PR TITLE
fixed issue R5 - removed `library(knitr)` as the package is not used

### DIFF
--- a/src/analyse_spacewalks.R
+++ b/src/analyse_spacewalks.R
@@ -7,7 +7,6 @@ library(dplyr)
 library(ggplot2)
 library(lubridate)
 library(tidyr)
-library(knitr)
 
 output_dir <- '/home/sarah/Projects/spacewalk-analysis/results/figures/'
 


### PR DESCRIPTION
fixed issue R5 - removed `library(knitr)` as the package is not used